### PR TITLE
feat: Docker HubへのCI pushワークフローを追加

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,39 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- masterブランチへのpush・`v*`タグpush時にDockerイメージをDocker Hubへ自動pushするGitHub Actionsワークフローを追加
- 認証情報・push先は一切コードに埋め込まず、すべてGitHub Secretsから読み込む

## 設定が必要なSecrets

マージ後、リポジトリの **Settings → Secrets and variables → Actions** で以下を登録してください:

| Secret名 | 説明 |
|---|---|
| `DOCKERHUB_USERNAME` | Docker HubユーザーID |
| `DOCKERHUB_TOKEN` | Docker Hub Access Token ([発行はこちら](https://hub.docker.com/settings/security)) |

イメージ名は `${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}` で動的構成されます。

## タグ戦略

- `master` push → `latest` タグ
- `v1.2.3` タグ push → `1.2.3` および `1.2` タグ

🤖 Generated with [Claude Code](https://claude.com/claude-code)