### PR TITLE
feat: ベースイメージをDHI Node.js 22 (sfw-dev) に移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 voice/
 .env
+.gstack/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:20.20.0-slim
-WORKDIR /tmp
-COPY package.json /tmp/package.json
-RUN npm install
-COPY main.js /tmp/main.js
+FROM dhi.io/node:22-alpine-sfw-dev
+
+WORKDIR /app
+COPY package.json package-lock.json /app/
+RUN npm ci --omit=dev
+COPY main.js /app/main.js
+
 ENTRYPOINT ["node"]
-CMD ["/tmp/main.js"]
+CMD ["/app/main.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,10 @@
                 "castv2-client": "^1.1.2",
                 "date-utils": "^1.2.21",
                 "express": "^4.17.1",
-                "express-rate-limit": "^8.5.2",
-                "fs": "0.0.2",
-                "os": "^0.1.1",
-                "path": "0.12.7",
-                "url": "^0.11.0"
+                "express-rate-limit": "^8.5.2"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -457,12 +456,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
-            "integrity": "sha512-YAiVokMCrSIFZiroB1oz51hPiPRVcUtSa4x2U5RYXyhS9VAPdiFigKbPTnOSq7XY8wd3FIVPYmXpo5lMzFmxgg==",
-            "license": "MIT"
-        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -715,12 +708,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/os": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
-            "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ==",
-            "license": "MIT"
-        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -730,30 +717,11 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/path": {
-            "version": "0.12.7",
-            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-            "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-            "license": "MIT",
-            "dependencies": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
-            }
-        },
         "node_modules/path-to-regexp": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
-        },
-        "node_modules/process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
-            }
         },
         "node_modules/protobufjs": {
             "version": "7.6.4",
@@ -790,12 +758,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.15.2",
@@ -1030,34 +992,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/url": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-            "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^1.4.1",
-                "qs": "^6.12.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "2.0.3"
-            }
-        },
-        "node_modules/util/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "license": "ISC"
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,12 @@
         "castv2-client": "^1.1.2",
         "date-utils": "^1.2.21",
         "express": "^4.17.1",
-        "express-rate-limit": "^8.5.2",
-        "fs": "0.0.2",
-        "os": "^0.1.1",
-        "path": "0.12.7",
-        "url": "^0.11.0"
+        "express-rate-limit": "^8.5.2"
     },
     "overrides": {
         "protobufjs": "^7.5.6"
+    },
+    "engines": {
+        "node": ">=22"
     }
 }


### PR DESCRIPTION
## Summary

- `node:20.20.0-slim` (Debian, Node.js 20 EOL 2026/04) → `dhi.io/node:22-alpine-sfw-dev` (DHI Community, Node.js 22 LTS EOL 2027/04)
- DHI Community プランは無償・Apache 2.0・Near-zero CVE
- Socket Firewall Free 同梱: `npm ci` 実行時に悪意あるパッケージをリアルタイムブロック

## 変更内容

| ファイル | 変更 |
|---|---|
| `Dockerfile` | ベースイメージ変更、WORKDIR `/tmp`→`/app`、`npm ci --omit=dev` に変更 |
| `package.json` | Node.js組み込みモジュールのpolyfill (fs/os/path/url) を削除、`engines` フィールド追加 |
| `package-lock.json` | 上記削除に伴う再生成 |

## Socket Firewallの検出内容

ビルド検証中、Socket Firewall が `fs@0.0.2` を **malware (critical)** として検出・ブロック。  
Node.js 組み込みの `fs` を正しく使うよう修正済み。

## ローカル検証

```
docker build → 成功
docker run --entrypoint node test-dhi --version → v22.23.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)