### PR TITLE
fix: GITHUB_TOKENの権限をcontents: readに制限 (Code Scanning #7)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- GitHub Code Scanning alert #7 (`actions/missing-workflow-permissions`) の修正
- `docker-publish.yml` に `permissions: contents: read` を追加
- `GITHUB_TOKEN` の権限をリポジトリのデフォルト (read-write) から最小権限に制限

## 根拠

| ステップ | 必要な権限 |
|---|---|
| `actions/checkout@v4` | `contents: read` |
| `docker/login-action@v3` | 不要 (Docker Hub外部認証) |
| `docker/build-push-action@v6` | 不要 (Docker Hub外部push) |

## Test plan

- [ ] PRマージ後、GitHub Code Scanning alert #7 が `fixed` に変わることを確認
- [ ] `master` push時にワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)