### PR TITLE
feat: buildx+QEMUでlinux/arm64マルチアーキテクチャビルドを追加

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -38,5 +44,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- QEMU + Docker Buildx のセットアップステップを追加
- `platforms: linux/amd64,linux/arm64` を指定してマルチアーキマニフェストを生成
- Raspberry Pi 4 (arm64) で `docker pull` 後にそのまま動作するイメージを配信

## 変更点

`.github/workflows/docker-publish.yml` に3箇所追加:
1. `docker/setup-qemu-action@v3` — arm64エミュレーション用
2. `docker/setup-buildx-action@v3` — マルチプラットフォームビルダー有効化
3. `platforms: linux/amd64,linux/arm64` — ビルド対象アーキテクチャ指定

ベースイメージ `dhi.io/node:22-alpine-sfw-dev` の arm64 マニフェスト存在を事前確認済み。

## Test plan

- [ ] GitHub Actions ワークフローが両アーキテクチャのビルドに成功すること
- [ ] マージ後 `docker buildx imagetools inspect <user>/google-home-voicetext-server:latest` で `linux/arm64` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)