### PR TITLE
fix: /autoplanレビュー指摘によるCIワークフローの品質改善

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,9 @@ on:
       - master
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -19,6 +22,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,7 +48,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

PR #55 でマージしたarm64マルチアーキテクチャビルドに対して、`/autoplan` レビューで指摘された3点を改善。

## 変更内容

1. **PR時のビルド検証追加** — `pull_request` トリガーを追加し、masterマージ前にQEMU+arm64ビルドが通ることを確認できるようにした（`push: false`）
2. **QEMUをarm64のみに限定** — `docker/setup-qemu-action` に `platforms: arm64` を追加し、不要なbinfmt登録を除去
3. **Buildxキャッシュ追加** — `cache-from/to: type=gha` を追加し、QEMU経由のarm64ビルドを高速化

## Test plan

- [ ] PRオープン時にGitHub ActionsでビルドジョブがキックされDocker Hubへのpushなしでビルドが成功すること
- [ ] masterマージ後のビルドで `linux/amd64` + `linux/arm64` 両方がpushされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)