### PR TITLE
feat: Dependabot cooldownを7日に設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` を新規作成し、Dependabot の cooldown を 7 日に設定します。

## 変更内容

- npm エコシステムの週次チェックを設定
- `cooldown.default-days: 7`：新バージョンのリリースから 7 日間は PR を作成しない

## 補足

- セキュリティアップデートには cooldown は適用されず、即時 PR が作成されます
- Docker ベースイメージ（`dhi.io/node:22-alpine-sfw-dev`）はプライベートレジストリのため Dependabot 対象外

🤖 Generated with [Claude Code](https://claude.ai/claude-code)