### PR TITLE
fix: PRビルド時はDocker Hubへのログインをスキップ

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Dependabot PRはリポジトリのシークレット（DOCKERHUB_USERNAME/DOCKERHUB_TOKEN）にアクセスできないため、Login to Docker Hub ステップが失敗します。PRビルドはイメージをpushしないため、ログインは不要です。yasu-hide/2jciebu-exporter#9 と同様の修正を適用します。