### PR TITLE
ci: dependabotのvitest系更新をグルーピング

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"


### PR DESCRIPTION
## 変更の概要
Dependabot の npm エコシステム設定に `groups` を追加し、vitest 関連パッケージ（`vitest`, `@vitest/*`）の更新を1本のPRにまとめるようにしました。

## 変更の理由/背景
`vitest` と `@vitest/coverage-v8` はバージョンを揃えて更新すべきパッケージですが、現状は個別PRが作られるため、マージの手間とCI実行が重複していました。google-home-voicetext-mqtt リポジトリで導入済みの設定と同一の構成に揃えます。

## 主な変更点
- `.github/dependabot.yml` の npm 設定に `groups.vitest` を追加
  - patterns: `vitest`, `@vitest/*`

## テスト方法
- 設定ファイルのみの変更のため動作テストなし
- 次回の Dependabot 実行時に vitest 系更新が1本のPRにまとまることを確認

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)